### PR TITLE
Add "mlat cutoff" option to bounce averaged diffusion coefficients script

### DIFF
--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -1,0 +1,16 @@
+Version 1.0.1
+=============
+
+New Features
+------------
+
+src/scripts/bounce_averaged_diffusion_coefficients.py
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Added the `mlat_cutoff` parameter to the input specification, allowins users to set a maximum
+  magnetic latitude beyond which it is assumed that no waves are present.
+
+Version 1.0.0
+=============
+
+- Initial release.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "PIRAN"
 copyright = "2023, O. Allanson"
 author = "O. Allanson"
-release = "0.1"
+release = "1.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,9 @@
 Welcome to PIRAN's documentation!
 =================================
 
+All the modules in PIRAN are listed below. See the :doc:`CHANGES <CHANGES>` file
+for a full list of the latest updates to PIRAN.
+
 .. toctree::
    :maxdepth: 2
    :caption: Modules:
@@ -19,6 +22,13 @@ Welcome to PIRAN's documentation!
    piran/plasmapoint
    piran/stix
    piran/wavefilter
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Latest Changes:
+   :hidden:
+
+   CHANGES
 
 Indices and tables
 ==================

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -117,12 +117,10 @@ def get_DnX_per_X(
 
     resonant_roots = cpdr.solve_resonant(X_range)
     for roots_this_x in resonant_roots:
-
         DnXaa_this_X = 0.0
         DnXap_this_X = 0.0
         DnXpp_this_X = 0.0
         for root in roots_this_x:
-
             if np.isnan(root.omega) or np.isnan(root.k):
                 continue
 
@@ -285,11 +283,9 @@ def main():
     baDpp_integrand = u.Quantity(np.zeros(mlat_npoints, dtype=np.float64), UNIT_DIFF)
 
     for ii, mlat in enumerate(lambda_range):
-
         if mlat >= mlat_cutoff:
             continue
 
-        
         pitch_angle = bounce.get_bounce_pitch_angle(mlat)
         if (
             np.isnan(pitch_angle)
@@ -358,7 +354,6 @@ def main():
         baDaa_integrand[ii] = Daa * bounce.get_pitch_angle_factor(mlat)
         baDap_integrand[ii] = Dap * bounce.get_mixed_factor(mlat)
         baDpp_integrand[ii] = Dpp * bounce.get_momentum_factor(mlat)
-
 
     # Scipy's simpson strips the units so we might want to re-add them here manually
     # If we don't, the unit will be "dimensionless_unscaled" which is incorrect.

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -353,13 +353,11 @@ def main():
             baDaa_integrand[ii] = Daa * bounce.get_pitch_angle_factor(mlat)
             baDap_integrand[ii] = Dap * bounce.get_mixed_factor(mlat)
             baDpp_integrand[ii] = Dpp * bounce.get_momentum_factor(mlat)
-            #print(mlat, baDaa_integrand[ii])      #oliver
 
         elif mlat >= li_cutoff:                   #oliver
             baDaa_integrand[ii] = 0.0 << UNIT_DIFF#oliver
             baDap_integrand[ii] = 0.0 << UNIT_DIFF#oliver
             baDpp_integrand[ii] = 0.0 << UNIT_DIFF#oliver
-            #print(mlat, baDaa_integrand[ii])      #oliver
 
     # Scipy's simpson strips the units so we might want to re-add them here manually
     # If we don't, the unit will be "dimensionless_unscaled" which is incorrect.

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -267,9 +267,7 @@ def main():
     # Create integration range for equations 24, 25 and 26 in Glauert 2005
     lambda_min = 0.0 << u.rad
     lambda_max = bounce.mirror_latitude << u.rad
-    lambda_range = Angle(
-        np.linspace(lambda_min, lambda_max, mlat_npoints), unit=u.rad
-    )
+    lambda_range = Angle(np.linspace(lambda_min, lambda_max, mlat_npoints), unit=u.rad)
     container["mlat_range"] = lambda_range.value.tolist()
 
     # Start the main loop over the magnetic latitudes.

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -285,9 +285,6 @@ def main():
         li_cutoff = 15.0* np.pi / 180.0 << u.rad#oliver
 
         if mlat >= li_cutoff:                   #oliver
-            baDaa_integrand[ii] = 0.0 << UNIT_DIFF#oliver
-            baDap_integrand[ii] = 0.0 << UNIT_DIFF#oliver
-            baDpp_integrand[ii] = 0.0 << UNIT_DIFF#oliver
             continue
 
         

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -25,6 +25,7 @@ Create an `input.json` file with the following:
 | "equatorial_pitch_angle" | Number           | 60.0                    | deg  |                                     |
 | "plasma_over_gyro_ratio" | Number           | 1.5                     |      |                                     |
 | "mlat_npoints"           | Number           | 30                      |      |                                     |
+| "mlat_cutoff"            | Number           | 15.0                    | deg  | Magnetic latitude cutoff            |
 | "l_shell"                | Number           | 4.5                     |      |                                     |
 | "resonances"             | Array of Numbers | [-2, -1, 0, 1]          |      |                                     |
 | "X_min"                  | Number           | 0.0                     |      |                                     |
@@ -43,6 +44,7 @@ for example:
     "equatorial_pitch_angle": 60.0,
     "plasma_over_gyro_ratio": 1.5,
     "mlat_npoints": 30,
+    "mlat_cutoff": 15.0,
     "l_shell": 4.5,
     "resonances": [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
     "X_min": 0.0,
@@ -208,6 +210,7 @@ def main():
     equatorial_pitch_angle = Angle(parameters["equatorial_pitch_angle"], u.deg)
     plasma_over_gyro_ratio = float(parameters["plasma_over_gyro_ratio"])
     mlat_npoints = int(parameters["mlat_npoints"])
+    mlat_cutoff = Angle(parameters["mlat_cutoff"], u.deg)
     l_shell = float(parameters["l_shell"])
     resonances = list(parameters["resonances"])
     X_min = float(parameters["X_min"]) << u.dimensionless_unscaled
@@ -228,6 +231,7 @@ def main():
     container["equatorial_pitch_angle"] = equatorial_pitch_angle.deg
     container["plasma_over_gyro_ratio"] = plasma_over_gyro_ratio
     container["mlat_npoints"] = mlat_npoints
+    container["mlat_cutoff"] = mlat_cutoff.deg
     container["l_shell"] = l_shell
     container["resonances"] = resonances
     container["X_min"] = X_min.value
@@ -282,9 +286,7 @@ def main():
 
     for ii, mlat in enumerate(lambda_range):
 
-        li_cutoff = 15.0* np.pi / 180.0 << u.rad
-
-        if mlat >= li_cutoff:
+        if mlat >= mlat_cutoff:
             continue
 
         

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -267,7 +267,7 @@ def main():
     # Create integration range for equations 24, 25 and 26 in Glauert 2005
     lambda_min = 0.0 << u.rad
     lambda_max = bounce.mirror_latitude << u.rad
-    lambda_range = u.Quantity(
+    lambda_range = Angle(
         np.linspace(lambda_min, lambda_max, mlat_npoints), unit=u.rad
     )
     container["mlat_range"] = lambda_range.value.tolist()

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -282,9 +282,9 @@ def main():
 
     for ii, mlat in enumerate(lambda_range):
 
-        li_cutoff = 15.0* np.pi / 180.0 << u.rad#oliver
+        li_cutoff = 15.0* np.pi / 180.0 << u.rad
 
-        if mlat >= li_cutoff:                   #oliver
+        if mlat >= li_cutoff:
             continue
 
         

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -205,10 +205,10 @@ def main():
 
     particles = tuple(parameters["particles"])
     energy = float(parameters["energy"]) << u.MeV
-    equatorial_pitch_angle = Angle(parameters["equatorial_pitch_angle"], u.deg)
+    equatorial_pitch_angle = Angle(float(parameters["equatorial_pitch_angle"]), u.deg)
     plasma_over_gyro_ratio = float(parameters["plasma_over_gyro_ratio"])
     mlat_npoints = int(parameters["mlat_npoints"])
-    mlat_cutoff = Angle(parameters["mlat_cutoff"], u.deg)
+    mlat_cutoff = Angle(float(parameters["mlat_cutoff"]), u.deg)
     l_shell = float(parameters["l_shell"])
     resonances = list(parameters["resonances"])
     X_min = float(parameters["X_min"]) << u.dimensionless_unscaled

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -18,24 +18,24 @@
 
 """
 Create an `input.json` file with the following:
-| Name                     | Data type        | Example                 | Unit | Info                                |
-|--------------------------|------------------|-------------------------|------|-------------------------------------|
-| "particles"              | Array of Strings | ["e", "p+"]             |      |                                     |
-| "energy"                 | Number           | 1.0                     | MeV  | Relativistic kinetic energy         |
-| "equatorial_pitch_angle" | Number           | 60.0                    | deg  |                                     |
-| "plasma_over_gyro_ratio" | Number           | 1.5                     |      |                                     |
-| "mlat_npoints"           | Number           | 30                      |      |                                     |
-| "mlat_cutoff"            | Number           | 15.0                    | deg  | Magnetic latitude cutoff            |
-| "l_shell"                | Number           | 4.5                     |      |                                     |
-| "resonances"             | Array of Numbers | [-2, -1, 0, 1]          |      |                                     |
-| "X_min"                  | Number           | 0.0                     |      |                                     |
-| "X_max"                  | Number           | 1.0                     |      |                                     |
-| "X_npoints"              | Number           | 1000                    |      |                                     |
-| "X_m"                    | Number           | 0.0                     |      | Peak                                |
-| "X_w"                    | Number           | 0.577                   |      | Angular width                       |
-| "freq_cutoff_params"     | Array of Numbers | [0.35, 0.15, -1.5, 1.5] |      | See par.30 Glauert and Horne 2005   |
-| "wave_amplitude"         | Number           | 1e-10                   | T    |                                     |
-| "method"                 | Number           | 0                       |      | 0 for Glauert, 1 for Cunningham     |
+| Name                     | Data type        | Example                 | Unit | Info                                                |
+|--------------------------|------------------|-------------------------|------|-----------------------------------------------------|
+| "particles"              | Array of Strings | ["e", "p+"]             |      |                                                     |
+| "energy"                 | Number           | 1.0                     | MeV  | Relativistic kinetic energy                         |
+| "equatorial_pitch_angle" | Number           | 60.0                    | deg  |                                                     |
+| "plasma_over_gyro_ratio" | Number           | 1.5                     |      |                                                     |
+| "mlat_npoints"           | Number           | 30                      |      |                                                     |
+| "mlat_cutoff"            | Number           | 15.0                    | deg  | Magnetic latitude cutoff (use "inf" if not desired) |
+| "l_shell"                | Number           | 4.5                     |      |                                                     |
+| "resonances"             | Array of Numbers | [-2, -1, 0, 1]          |      |                                                     |
+| "X_min"                  | Number           | 0.0                     |      |                                                     |
+| "X_max"                  | Number           | 1.0                     |      |                                                     |
+| "X_npoints"              | Number           | 1000                    |      |                                                     |
+| "X_m"                    | Number           | 0.0                     |      | Peak                                                |
+| "X_w"                    | Number           | 0.577                   |      | Angular width                                       |
+| "freq_cutoff_params"     | Array of Numbers | [0.35, 0.15, -1.5, 1.5] |      | See par.30 Glauert and Horne 2005                   |
+| "wave_amplitude"         | Number           | 1e-10                   | T    |                                                     |
+| "method"                 | Number           | 0                       |      | 0 for Glauert, 1 for Cunningham                     |
 
 for example:
 {
@@ -58,6 +58,9 @@ for example:
 }
 
 and run the script as: `python path/to/bounce_averaged_diffusion_coefficients.py -i path/to/input.json`
+
+The mlat_cutoff setting is used to impose a maximum magnetic latitude at which waves are present
+(disregarding any solutions beyond this point). If this is not desired, set it to "inf".
 
 The script will create a file `results_[ANGLE]deg_[ENERGY]MeV.json` in the
 current working directory, where [ANGLE] is the equatorial pitch angle in degrees

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -282,74 +282,84 @@ def main():
 
     for ii, mlat in enumerate(lambda_range):
 
-        pitch_angle = bounce.get_bounce_pitch_angle(mlat)
-        if (
-            np.isnan(pitch_angle)
-            or pitch_angle <= 0.0 << u.rad
-            or pitch_angle >= np.pi / 2 << u.rad
-        ):
-            continue
+        li_cutoff = 15.0* np.pi / 180.0 << u.rad#oliver
+        if mlat < li_cutoff:                    #oliver  
+        
+            pitch_angle = bounce.get_bounce_pitch_angle(mlat)
+            if (
+                np.isnan(pitch_angle)
+                or pitch_angle <= 0.0 << u.rad
+                or pitch_angle >= np.pi / 2 << u.rad
+            ):
+                continue
 
-        mag_point = MagPoint(mlat, l_shell)
-        plasma_point = PlasmaPoint(mag_point, particles, plasma_over_gyro_ratio)
+            mag_point = MagPoint(mlat, l_shell)
+            plasma_point = PlasmaPoint(mag_point, particles, plasma_over_gyro_ratio)
 
-        Dnaa = []
-        Dnap = []
-        Dnpp = []
-        for resonance in resonances:
-            cpdr = Cpdr(
-                plasma_point,
-                energy,
-                pitch_angle,
-                resonance,
-                freq_cutoff_params,
-            )
+            Dnaa = []
+            Dnap = []
+            Dnpp = []
+            for resonance in resonances:
+                cpdr = Cpdr(
+                    plasma_point,
+                    energy,
+                    pitch_angle,
+                    resonance,
+                    freq_cutoff_params,
+                )
 
-            # Depends only on energy and mass. Will be the same for different
-            # resonances and latitudes.
-            container["momentum"] = cpdr.momentum.value
-            container["rest_mass_energy_Joule"] = (
-                (cpdr.plasma.particles[0].mass.to(u.kg) * const.c**2).to(u.J).value
-            )
+                # Depends only on energy and mass. Will be the same for different
+                # resonances and latitudes.
+                container["momentum"] = cpdr.momentum.value
+                container["rest_mass_energy_Joule"] = (
+                    (cpdr.plasma.particles[0].mass.to(u.kg) * const.c**2).to(u.J).value
+                )
 
-            # Calculate equations 11, 12 and 13 from
-            # Glauert & Horne 2005, for this resonance.
-            DnXaa_this_res, DnXap_this_res, DnXpp_this_res = get_DnX_per_X(
-                cpdr,
-                X_range,
-                X_max,
-                epsilon,
-                wave_norm_angle_dist,
-                integral_gx,
-                wave_amplitude,
-                method,
-            )
+                # Calculate equations 11, 12 and 13 from
+                # Glauert & Horne 2005, for this resonance.
+                DnXaa_this_res, DnXap_this_res, DnXpp_this_res = get_DnX_per_X(
+                    cpdr,
+                    X_range,
+                    X_max,
+                    epsilon,
+                    wave_norm_angle_dist,
+                    integral_gx,
+                    wave_amplitude,
+                    method,
+                )
 
-            # Calculate the integrals from equations 8, 9 and 10 in
-            # Glauert & Horne 2005, only for this resonance.
-            Dnaa_this_res = get_diffusion_coefficients(
-                X_range, DnXaa_this_res << UNIT_DIFF
-            )
-            Dnap_this_res = get_diffusion_coefficients(
-                X_range, DnXap_this_res << UNIT_DIFF
-            )
-            Dnpp_this_res = get_diffusion_coefficients(
-                X_range, DnXpp_this_res << UNIT_DIFF
-            )
-            Dnaa.append(Dnaa_this_res)
-            Dnap.append(Dnap_this_res)
-            Dnpp.append(Dnpp_this_res)
+                # Calculate the integrals from equations 8, 9 and 10 in
+                # Glauert & Horne 2005, only for this resonance.
+                Dnaa_this_res = get_diffusion_coefficients(
+                    X_range, DnXaa_this_res << UNIT_DIFF
+                )
+                Dnap_this_res = get_diffusion_coefficients(
+                    X_range, DnXap_this_res << UNIT_DIFF
+                )
+                Dnpp_this_res = get_diffusion_coefficients(
+                    X_range, DnXpp_this_res << UNIT_DIFF
+                )
+                Dnaa.append(Dnaa_this_res)
+                Dnap.append(Dnap_this_res)
+                Dnpp.append(Dnpp_this_res)
 
-        # Sum the diffusion coefficients for all the resonances.
-        # This is essentially what is calculated in equations 8, 9
-        # and 10 in Glauert & Horne 2005.
-        Daa = np.sum([v.value for v in Dnaa]) << UNIT_DIFF
-        Dap = np.sum([v.value for v in Dnap]) << UNIT_DIFF
-        Dpp = np.sum([v.value for v in Dnpp]) << UNIT_DIFF
+            # Sum the diffusion coefficients for all the resonances.
+            # This is essentially what is calculated in equations 8, 9
+            # and 10 in Glauert & Horne 2005.
+            Daa = np.sum([v.value for v in Dnaa]) << UNIT_DIFF
+            Dap = np.sum([v.value for v in Dnap]) << UNIT_DIFF
+            Dpp = np.sum([v.value for v in Dnpp]) << UNIT_DIFF
 
-        baDaa_integrand[ii] = Daa * bounce.get_pitch_angle_factor(mlat)
-        baDap_integrand[ii] = Dap * bounce.get_mixed_factor(mlat)
-        baDpp_integrand[ii] = Dpp * bounce.get_momentum_factor(mlat)
+            baDaa_integrand[ii] = Daa * bounce.get_pitch_angle_factor(mlat)
+            baDap_integrand[ii] = Dap * bounce.get_mixed_factor(mlat)
+            baDpp_integrand[ii] = Dpp * bounce.get_momentum_factor(mlat)
+            #print(mlat, baDaa_integrand[ii])      #oliver
+
+        elif mlat >= li_cutoff:                   #oliver
+            baDaa_integrand[ii] = 0.0 << UNIT_DIFF#oliver
+            baDap_integrand[ii] = 0.0 << UNIT_DIFF#oliver
+            baDpp_integrand[ii] = 0.0 << UNIT_DIFF#oliver
+            #print(mlat, baDaa_integrand[ii])      #oliver
 
     # Scipy's simpson strips the units so we might want to re-add them here manually
     # If we don't, the unit will be "dimensionless_unscaled" which is incorrect.


### PR DESCRIPTION
I've mostly preserved Oliver's original implementation in this, which has one feature I think is worth further discussion.

We now define both an `mlat_npoints` and an `mlat_cutoff`. We go through a process of:

- calculate `lambda_max` (the mirror latitude)
- set up `lambda_range`, linearly spacing `mlat_npoints` points between `0` and `lambda_max`
- while looping over `lambda_range`, skip over any points for which the current mlat is larger than `mlat_cutoff`

This preserves a fixed(ish) mesh size. I think this is probably OK, it just might need a bit more explaining (i.e. it feels weird to define a fixed `mlat_npoints` and then not use all of them). The alternative might be to preserve a fixed number of points, in which we would linearly space `mlat_npoints` between `0` and the smaller of `lambda_max` or `mlat_cutoff`. This potentially introduces varying mesh sizes for differing params while keeping `mlat_npoints` fixed, which feels less tractable. Note that linspacing between `0` and `lambda_max` (which varies) already introduces some varying mesh sizes regardless.

Also to be considered: **does this require a version bump to 1.0.1?** Never sure how these scripts should be accounted for when considering versioning of the PIRAN package...

Update: following conversation with Oliver, I've bumped this to 1.0.1 and added a changelog in the docs to start tracking what goes into each new version. I don't think we should actually change the git tag with this MR yet, since the next few changes I'm about to make can all probably go into 1.0.1 too. These are:

- resolving ambiguity at mirror point
- adding a warning when we encounter a negative sqrt
- adding a lower limit to the whistler filter