### PR TITLE
cap range of integration over mlat

### DIFF
--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -10,6 +10,22 @@ src/scripts/bounce_averaged_diffusion_coefficients.py
 - Added the `mlat_cutoff` parameter to the input specification, allowins users to set a maximum
   magnetic latitude beyond which it is assumed that no waves are present.
 
+Bug Fixes
+---------
+
+src/scripts/bounce_averaged_diffusion_coefficients.py
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Cap the upper limit on the range of integration over the magnetic latitude to 0.9999 times
+  the mirror point, to ensure we use a consistent approach for the integrable singularity at the
+  mirror point. Previously, when calculating the integrand at the mirror point
+  `Bounce.get_bounce_pitch_angle` would return either exactly `pi/2` or a value very close to it
+  (approaching from below), dependent on floating point precision. The `pi/2` pitch angle gets
+  skipped (for being singular) whereas anything else is included. Capping the magnetic latitude at
+  0.9999 times the mirror point ensures that we don't have to deal with this ambiguity. A more
+  robust long-term solution might be to re-examine the behaviour of `Bounce.get_bounce_pitch_angle`
+  and look for a way to more accurately evaluate the integrand at the mirror point.
+
 Version 1.0.0
 =============
 

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -269,7 +269,7 @@ def main():
 
     # Create integration range for equations 24, 25 and 26 in Glauert 2005
     lambda_min = 0.0 << u.rad
-    lambda_max = bounce.mirror_latitude << u.rad
+    lambda_max = 0.9999 * bounce.mirror_latitude << u.rad # Cap this at 0.9999 to avoid (integrable) singularity
     lambda_range = Angle(np.linspace(lambda_min, lambda_max, mlat_npoints), unit=u.rad)
     container["mlat_range"] = lambda_range.value.tolist()
 

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -269,7 +269,9 @@ def main():
 
     # Create integration range for equations 24, 25 and 26 in Glauert 2005
     lambda_min = 0.0 << u.rad
-    lambda_max = 0.9999 * bounce.mirror_latitude << u.rad # Cap this at 0.9999 to avoid (integrable) singularity
+    lambda_max = (
+        0.9999 * bounce.mirror_latitude << u.rad
+    )  # Cap this at 0.9999 to avoid (integrable) singularity
     lambda_range = Angle(np.linspace(lambda_min, lambda_max, mlat_npoints), unit=u.rad)
     container["mlat_range"] = lambda_range.value.tolist()
 


### PR DESCRIPTION
**Not to be merged before #7**

---

Copying description from CHANGES.rst:

>Cap the upper limit on the range of integration over the magnetic latitude to 0.9999 times the mirror point, to ensure we use a consistent approach for the integrable singularity at the mirror point. Previously, when calculating the integrand at the mirror point `Bounce.get_bounce_pitch_angle` would return either exactly `pi/2` or a value very close to it (approaching from below), dependent on floating point precision. The `pi/2` pitch angle gets skipped (for being singular) whereas anything else is included. Capping the magnetic latitude at 0.9999 times the mirror point ensures that we don't have to deal with this ambiguity. A more robust long-term solution might be to re-examine the behaviour of `Bounce.get_bounce_pitch_angle` and look for a way to more accurately evaluate the integrand at the mirror point.