### PR TITLE
add warning for imaginary resonance cone angle

### DIFF
--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -32,9 +32,7 @@ Other Changes and Additions
 src/scripts/bounce_averaged_diffusion_coefficients.py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Added a warning message that is printed when the resonance cone angle is negative. This warning
-  is printed only once, alongside the NumPy RuntimeWarning that is raised when a negative number
-  is passed to `np.sqrt`.
+- Added a warning message that is printed when the resonance cone angle is negative.
 
 Version 1.0.0
 =============

--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -26,6 +26,16 @@ src/scripts/bounce_averaged_diffusion_coefficients.py
   robust long-term solution might be to re-examine the behaviour of `Bounce.get_bounce_pitch_angle`
   and look for a way to more accurately evaluate the integrand at the mirror point.
 
+Other Changes and Additions
+---------------------------
+
+src/scripts/bounce_averaged_diffusion_coefficients.py
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Added a warning message that is printed when the resonance cone angle is negative. This warning
+  is printed only once, alongside the NumPy RuntimeWarning that is raised when a negative number
+  is passed to `np.sqrt`.
+
 Version 1.0.0
 =============
 

--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -32,7 +32,7 @@ Other Changes and Additions
 src/scripts/bounce_averaged_diffusion_coefficients.py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Added a warning message that is printed when the resonance cone angle is negative.
+- Added a warning message that is printed when the resonance cone angle is imaginary.
 
 Version 1.0.0
 =============

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -128,15 +128,16 @@ def get_DnX_per_X(
             if np.isnan(root.omega) or np.isnan(root.k):
                 continue
 
+            # Cap the value of X according to the resonance cone angle
             # See par.23 in Glauert & Horne 2005
-            resonance_cone_angle = -cpdr.stix.P(root.omega) / cpdr.stix.S(root.omega)
+            rca_squared = -cpdr.stix.P(root.omega) / cpdr.stix.S(root.omega)
 
-            if resonance_cone_angle < 0:
-                print(f"Warning: resonance cone angle < 0 for omega={root.omega}")
+            if rca_squared < 0:
+                print(f"Warning: imaginary resonance cone angle for omega={root.omega}")
 
             X_upper = (
-                min(X_max, epsilon * np.sqrt(resonance_cone_angle))
-                if resonance_cone_angle >= 0
+                min(X_max, epsilon * np.sqrt(rca_squared))
+                if rca_squared >= 0
                 else X_max
             )
             if root.X.value > X_upper.value:

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -136,7 +136,7 @@ def get_DnX_per_X(
 
             X_upper = (
                 min(X_max, epsilon * np.sqrt(resonance_cone_angle))
-                if resonance_cone_angle > 0
+                if resonance_cone_angle >= 0
                 else X_max
             )
             if root.X.value > X_upper.value:

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -107,7 +107,6 @@ def get_DnX_per_X(
     integral_gx,
     wave_amplitude,
     method,
-    caught_warning,
 ):
     """
     Given a cpdr object (which means that resonance is fixed) calculate
@@ -135,11 +134,11 @@ def get_DnX_per_X(
             if resonance_cone_angle < 0:
                 print(f"Warning: resonance cone angle < 0 for omega={root.omega}")
 
-                if not caught_warning[0]:
-                    print("NumPy will raise a RuntimeWarning shortly (but only once!)")
-                    caught_warning[0] = True
-
-            X_upper = min(X_max, epsilon * np.sqrt(resonance_cone_angle))
+            X_upper = (
+                min(X_max, epsilon * np.sqrt(resonance_cone_angle))
+                if resonance_cone_angle > 0
+                else X_max
+            )
             if root.X.value > X_upper.value:
                 continue
 
@@ -295,12 +294,6 @@ def main():
     baDap_integrand = u.Quantity(np.zeros(mlat_npoints, dtype=np.float64), UNIT_DIFF)
     baDpp_integrand = u.Quantity(np.zeros(mlat_npoints, dtype=np.float64), UNIT_DIFF)
 
-    # Sometimes we get a RuntimeWarning from NumPy when we feed a sqrt a negative number.
-    # We catch this and print a message to explain what is happening. We only want this
-    # to happen once, so we need a bool to track if we have already caught it. The bool
-    # also needs to be mutable after being passed to a function, so we use a list.
-    caught_warning = [False]
-
     for ii, mlat in enumerate(lambda_range):
         if mlat >= mlat_cutoff:
             continue
@@ -346,7 +339,6 @@ def main():
                 integral_gx,
                 wave_amplitude,
                 method,
-                caught_warning,
             )
 
             # Calculate the integrals from equations 8, 9 and 10 in


### PR DESCRIPTION
**Not to be merged before #8**

---

We also now skip using np.sqrt when we already know the resonance cone angle is imaginary, to avoid the confusing runtime warning from numpy.