### PR TITLE
Add a lower bound to WhistlerFilter

### DIFF
--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -4,6 +4,13 @@ Version 1.0.1
 New Features
 ------------
 
+piran/plasmapoint.py
+^^^^^^^^^^^^^^^^^^^^
+
+- Added a `lower_hybrid_freq` property to enable users to conveniently obtain the lower
+  hybrid frequency for each particle in a plasma without the need to (re-)calculate this
+  separately.
+
 src/scripts/bounce_averaged_diffusion_coefficients.py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -12,6 +19,15 @@ src/scripts/bounce_averaged_diffusion_coefficients.py
 
 Bug Fixes
 ---------
+
+piran/wavefilter.py
+^^^^^^^^^^^^^^^^^^^
+
+- Used the newly added `PlasmaPoint.lower_hybrid_freq` property to set a lower bound
+  (the lower hybrid frequency for protons) on the acceptable frequency range in `WhistlerFilter`.
+  There is an implicit assumption in here that we are only looking at electron-proton plasmas,
+  which will need to be addressed when we improve the support for more complicated plasma
+  compositions in the future.
 
 src/scripts/bounce_averaged_diffusion_coefficients.py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/piran/tests/test_plasmapoint.py
+++ b/piran/tests/test_plasmapoint.py
@@ -49,6 +49,8 @@ class TestPlasmaPoint:
         assert math.isclose(plasma_point.gyro_freq[1].value, 32.5464, rel_tol=1e-5)
         assert math.isclose(plasma_point.plasma_freq[0].value, 89640.33, rel_tol=1e-6)
         assert math.isclose(plasma_point.plasma_freq[1].value, 2091.93, rel_tol=1e-5)
+        assert math.isclose(plasma_point.lower_hybrid_freq[0].value, 49723.50956478517)
+        assert math.isclose(plasma_point.lower_hybrid_freq[1].value, 1160.399090097096)
 
     def test_plasmapoint_2(self):
         mlat_deg = Angle(0 * u.deg)
@@ -72,6 +74,8 @@ class TestPlasmaPoint:
         assert math.isclose(plasma_point.gyro_freq[1].value, 32.5407, rel_tol=1e-5)
         assert math.isclose(plasma_point.plasma_freq[0].value, 89640.33, rel_tol=1e-6)
         assert math.isclose(plasma_point.plasma_freq[1].value, 2091.75, rel_tol=1e-5)
+        assert math.isclose(plasma_point.lower_hybrid_freq[0].value, 49723.50956478517)
+        assert math.isclose(plasma_point.lower_hybrid_freq[1].value, 1160.2983285821322)
 
     def test_plasmapoint_3(self):
         """
@@ -110,6 +114,9 @@ class TestPlasmaPoint:
 
         assert math.isclose(plasma_point.plasma_freq[0].value, 89640.33, rel_tol=1e-6)
         assert math.isclose(plasma_point.plasma_freq[1].value, 2091.93, rel_tol=1e-5)
+
+        assert math.isclose(plasma_point.lower_hybrid_freq[0].value, 49723.50956392233)
+        assert math.isclose(plasma_point.lower_hybrid_freq[1].value, 1160.3990900769597)
 
         assert math.isclose(plasma_point.number_density[0].value, 2524781.78)
         assert math.isclose(plasma_point.number_density[1].value, 2524781.78)

--- a/piran/wavefilter.py
+++ b/piran/wavefilter.py
@@ -108,9 +108,13 @@ class WhistlerFilter(WaveFilter):
         plasma: PlasmaPoint,
         stix: Stix,
     ) -> bool:
-
-        # Frequency for Whistlers does not exceed electron plasma- or gyro-frequency
-        if omega > min(abs(plasma.gyro_freq[0]), abs(plasma.plasma_freq[0])):
+        # Frequency for Whistlers is bounded below by the lower hybrid frequency for protons
+        # and bounded above by the electron plasma- or gyro-frequency (whichever is smaller)
+        if (
+            not plasma.lower_hybrid_freq[1]
+            <= omega
+            <= min(abs(plasma.gyro_freq[0]), abs(plasma.plasma_freq[0]))
+        ):
             return False
 
         # The square of the index of refraction is:


### PR DESCRIPTION
**Not to be merged before #9** 

---

As per Artemyev 2016 ("Oblique Whistler-Mode Waves in the Earth's Inner Magnetosphere..."):

>Whistler-mode waves are electromagnetic waves propagating at frequencies comprised between the lower-hybrid frequency ... and [the electron gyrofrequency]

For frequencies below the lower hybrid frequency, the value of -P/S is negative and so our calculation of the resonance cone angle (as per Eq 20 of Glauert and Horne 2005) starts to hit imaginary values. We won't see this anymore with this change.

I've used plasmapy's [lower_hybrid_frequency](https://docs.plasmapy.org/en/stable/api/plasmapy.formulary.frequencies.lower_hybrid_frequency.html) method for this, consistent with our use of plasmapy's methods for gyro- and plasma- frequencies.