### PR TITLE
Update bounce_averaged_diffusion_coefficients.py

### DIFF
--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -312,7 +312,11 @@ def main():
             plasma_point = PlasmaPoint(mag_point, particles, plasma_over_gyro_ratio)
             number_density_at_equator = plasma_point.number_density
         else: 
-            plasma_point = PlasmaPoint(mag_point, particles, number_density=number_density_at_equator)
+            plasma_point = PlasmaPoint(
+                mag_point,
+                particles,
+                number_density=number_density_at_equator
+            )
 
         Dnaa = []
         Dnap = []

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -308,7 +308,11 @@ def main():
             continue
 
         mag_point = MagPoint(mlat, l_shell)
-        plasma_point = PlasmaPoint(mag_point, particles, plasma_over_gyro_ratio)
+        if mlat == lambda_min: 
+            plasma_point = PlasmaPoint(mag_point, particles, plasma_over_gyro_ratio)
+            number_density_at_equator = plasma_point.number_density
+        else: 
+            plasma_point = PlasmaPoint(mag_point, particles, number_density=number_density_at_equator)
 
         Dnaa = []
         Dnap = []

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -313,9 +313,7 @@ def main():
             number_density_at_equator = plasma_point.number_density
         else: 
             plasma_point = PlasmaPoint(
-                mag_point,
-                particles,
-                number_density=number_density_at_equator
+                mag_point, particles, number_density=number_density_at_equator
             )
 
         Dnaa = []

--- a/src/scripts/bounce_averaged_diffusion_coefficients.py
+++ b/src/scripts/bounce_averaged_diffusion_coefficients.py
@@ -308,10 +308,10 @@ def main():
             continue
 
         mag_point = MagPoint(mlat, l_shell)
-        if mlat == lambda_min: 
+        if mlat == lambda_min:
             plasma_point = PlasmaPoint(mag_point, particles, plasma_over_gyro_ratio)
             number_density_at_equator = plasma_point.number_density
-        else: 
+        else:
             plasma_point = PlasmaPoint(
                 mag_point, particles, number_density=number_density_at_equator
             )


### PR DESCRIPTION
Bounce averaging now insists that number density is fixed along a field line.

Previously, fpe/fce was fixed.