### PR TITLE
add additional conditions to WhistlerFilter

### DIFF
--- a/piran/wavefilter.py
+++ b/piran/wavefilter.py
@@ -108,10 +108,13 @@ class WhistlerFilter(WaveFilter):
         plasma: PlasmaPoint,
         stix: Stix,
     ) -> bool:
-        # Frequency for Whistlers is bounded below by the lower hybrid frequency for protons
-        # and bounded above by the electron plasma- or gyro-frequency (whichever is smaller)
+        # Frequency for Whistlers is bounded:
+        # - below by the proton lower hybrid frequency or gyrofrequency
+        #   (whichever is larger)
+        # - above by the electron plasma- or gyro-frequency
+        #   (whichever is smaller)
         if (
-            not plasma.lower_hybrid_freq[1]
+            not max(plasma.lower_hybrid_freq[1], abs(plasma.gyro_freq[1]))
             <= omega
             <= min(abs(plasma.gyro_freq[0]), abs(plasma.plasma_freq[0]))
         ):

--- a/piran/wavefilter.py
+++ b/piran/wavefilter.py
@@ -120,6 +120,13 @@ class WhistlerFilter(WaveFilter):
         ):
             return False
 
+        # Whistler waves should not exist if the resonance cone angle is imaginary
+        # See par.23 in Glauert & Horne 2005
+        rca_squared = -stix.P(omega) / stix.S(omega)
+
+        if rca_squared < 0:
+            return False
+
         # The square of the index of refraction is:
         # - bounded by R below
         # - unbounded above


### PR DESCRIPTION
**Not to be merged before #13**

- lower bound for frequency is now the max of either the (proton) lower hybrid frequency **or** the proton gyrofrequency
- we now additionally filter out waves for which the resonance cone angle is imaginary

This RCA stuff in particular introduces two things I don't like much:

- we still need to leave the `rca_squared` calculation in place in bounce_averaged_diffusion_coefficients.py and diffusion_coefficients.py to compute `X_upper`. i.e. we're repeating the calculation of the RCA across two places.
- we're now trivially recalculating the RCA for **all** waves that pass through the `WhistlerFilter` in `compute_glauert_norm_factor` (where `omega` is fixed according to the resonant value). In hindsight, the frequency bounds checks are also trivial for unchanging omega. We might eventually want different filters for resonant cpdr solns (omega unfixed) vs non-resonant norm factor cpdr solns (omega fixed) if the additional checks are provably having a negative impact on performance (but there's probably lower hanging fruit here).